### PR TITLE
Show the currently selected theme instead of initially showing "System Default"

### DIFF
--- a/PersianCalendar/src/main/kotlin/com/byagowi/persiancalendar/ui/settings/interfacecalendar/InterfaceCalendarFragment.kt
+++ b/PersianCalendar/src/main/kotlin/com/byagowi/persiancalendar/ui/settings/interfacecalendar/InterfaceCalendarFragment.kt
@@ -190,7 +190,7 @@ class InterfaceCalendarFragment : PreferenceFragmentCompat() {
         ) {
             preference = this
             summary = entries[entryValues.indexOf(
-                context.appPrefs.getString(key, null) ?: Theme.SYSTEM_DEFAULT.key
+                context.appPrefs.getString(PREF_THEME, null) ?: Theme.SYSTEM_DEFAULT.key
             )]
             title(R.string.select_skin)
         }


### PR DESCRIPTION
When the "Interface and Calendar" settings screen is opened, the "Select Skin" option does not correctly reflect the currently selected theme. For example, on my device the theme is set to "Dark" but it shows "System Default".
This PR fixes this issue.