### PR TITLE
Added Rounded Corner Dimensions to Display Cutout Info

### DIFF
--- a/PersianCalendar/src/main/kotlin/com/byagowi/persiancalendar/ui/about/DeviceInformationScreen.kt
+++ b/PersianCalendar/src/main/kotlin/com/byagowi/persiancalendar/ui/about/DeviceInformationScreen.kt
@@ -24,6 +24,7 @@ import android.text.style.ClickableSpan
 import android.util.AttributeSet
 import android.view.InputDevice
 import android.view.MenuItem
+import android.view.RoundedCorner
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.ColorInt
@@ -361,6 +362,22 @@ private class DeviceInformationAdapter(private val activity: FragmentActivity) :
                     "Safe Inset Bottom" to cutout.safeInsetBottom,
                     "Safe Inset Left" to cutout.safeInsetLeft,
                     "Rects" to cutout.boundingRects.joinToString(",")
+                ).joinToString("\n") { (key, value) -> "$key: $value" }
+            } else "None"
+        ),
+        Item(
+            "Rounded corners", if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) run {
+                val windowInsets = activity.window?.decorView?.rootWindowInsets
+                val topLeftCorner = windowInsets?.getRoundedCorner(RoundedCorner.POSITION_TOP_LEFT)
+                    ?: return@run "None"
+                val topRightCorner = windowInsets.getRoundedCorner(RoundedCorner.POSITION_TOP_RIGHT)
+                val bottomRightCorner = windowInsets.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_RIGHT)
+                val bottomLeftCorner = windowInsets.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_LEFT)
+                listOf(
+                    "Top left corner" to "radius=${topLeftCorner.radius} center=${topLeftCorner.center.toString()}",
+                    "Top right corner" to "radius=${topRightCorner?.radius} center=${topRightCorner?.center.toString()}",
+                    "Bottom right corner" to "radius=${bottomRightCorner?.radius} center=${bottomRightCorner?.center.toString()}",
+                    "Bottom left corner" to "radius=${bottomLeftCorner?.radius} center=${bottomLeftCorner?.center.toString()}"
                 ).joinToString("\n") { (key, value) -> "$key: $value" }
             } else "None"
         ),


### PR DESCRIPTION
This pull request adds the radius and centers of rounded corners to the existing display cutout information in the app. Many popular apps like **DevCheck** and **Castro** do _not_ include this feature in their display specification pages, and this app, being lightweight, is easy to install even on low-end devices.

To ensure compatibility, if a device is below Android API 32 or does not have rounded corners, the app will display `None` for the rounded corners' sizes.

I have tested the changes on a Galaxy A34 and the latest version of the Android Emulator with API 34, and the screenshots attached to the PR demonstrate the code I've added.

![Galaxy A34 screenshot with the rounded corners info](https://github.com/persian-calendar/persian-calendar/assets/4181752/e962f44d-c89a-4250-a054-af25e8367b9f)

![Android emulator screenshot with the rounded corners info](https://github.com/persian-calendar/persian-calendar/assets/4181752/a78dbd33-25f6-4daf-8ac8-3dc61fa1b1fa)
