### PR TITLE
Having same holiday text color when selected day is holiday

### DIFF
--- a/PersianCalendar/src/main/kotlin/com/byagowi/persiancalendar/ui/calendar/calendarpager/DaysTable.kt
+++ b/PersianCalendar/src/main/kotlin/com/byagowi/persiancalendar/ui/calendar/calendarpager/DaysTable.kt
@@ -322,7 +322,7 @@ fun SharedTransitionScope.DaysTable(
                         mainCalendarDigits,
                     ),
                     color = when {
-                        isSelected -> monthColors.textDaySelected
+                        isSelected -> if (isHoliday) monthColors.holidays else monthColors.textDaySelected
                         isHoliday -> monthColors.holidays
                         else -> contentColor
                     },


### PR DESCRIPTION
سلام
زمانی که روز انتخاب شده روز تعطیل باشد رنگ روز به روز عادی تغییر میکرد که باعث میشد متوجه نشویم روز تعطیل است یا خیر.

![Screenshot_20250706_202753](https://github.com/user-attachments/assets/cdd0f681-575d-4c83-8510-646cf904fef5)
![Screenshot_20250706_202744](https://github.com/user-attachments/assets/7f81e85a-17c9-4884-8ebc-54be672d2774)

تغییر کوچکی دادم که به این صورت نمایش داده شود
![Screenshot_20250706_202703](https://github.com/user-attachments/assets/2481977d-911f-4cd9-a9ad-c33c99141ab1)
![Screenshot_20250706_202715](https://github.com/user-attachments/assets/d5f28267-4b4d-4c2b-8187-fea21fba8af9)
